### PR TITLE
automatically recommend the VS Code WPILib extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["wpilibsuite.vscode-wpilib"]
+}


### PR DESCRIPTION
this PR make it so that if someone opens this repo in VS Code, VS Code will recommend that they install the official WPILib extension